### PR TITLE
create: add v6_connect_timeout and resolve_retries

### DIFF
--- a/src/happy_eyeballs.ml
+++ b/src/happy_eyeballs.ml
@@ -11,6 +11,7 @@ type connection = {
   state : conn_state ;
   ports : int list ;
   resolved : [ `none | `v4 | `v6 | `both ] ;
+  resolve_left : int ;
 }
 
 let resolve st ev = match st, ev with
@@ -24,9 +25,11 @@ module IM = Map.Make(Int)
 
 type t = {
   aaaa_timeout : int64 ;
+  v6_connect_timeout : int64 ;
   connect_timeout : int64 ;
   resolve_timeout : int64 ;
   started : int64 ;
+  resolve_retries : int ;
   conns : connection IM.t Domain_name.Host_map.t ;
 }
 
@@ -75,13 +78,17 @@ let pp_event ppf = function
 
 let create
     ?(aaaa_timeout = Duration.of_ms 50)
-    ?(connect_timeout = Duration.of_sec 1)
+    ?(v6_connect_timeout = Duration.of_ms 200)
+    ?(connect_timeout = Duration.of_sec 10)
     ?(resolve_timeout = Duration.of_sec 1)
+    ?(resolve_retries = 3)
     started =
   {
     aaaa_timeout ;
+    v6_connect_timeout ;
     connect_timeout ;
     resolve_timeout ;
+    resolve_retries ;
     started ;
     conns = Domain_name.Host_map.empty ;
   }
@@ -103,23 +110,40 @@ let expand_list_split ips ports =
   | _ -> failwith "ips or ports are empty"
 
 let tick t now host id conn =
-  match
-    match conn.state with
-    | Resolving when Int64.sub now conn.created > t.resolve_timeout ->
-      Error () (* TODO retry resolution *)
-    | Waiting_for_aaaa (started, ips) when Int64.sub now started > t.aaaa_timeout ->
-      let ips = List.map (fun ip -> Ipaddr.V4 ip) (Ipaddr.V4.Set.elements ips) in
-      let dst, dsts = expand_list_split ips conn.ports in
-      Ok (Connecting (now, dst, dsts), [ Connect (host, id, dst) ])
-    | Connecting (started, _dst, dsts) when Int64.sub now started > t.connect_timeout->
+  match conn.state with
+  | Resolving when Int64.sub now conn.created > t.resolve_timeout ->
+    if conn.resolve_left = 0 then
+      Error ()
+    else
+      Ok ({ conn with created = now ; resolve_left = conn.resolve_left - 1 },
+          [ Resolve_a host ; Resolve_aaaa host ])
+  | Waiting_for_aaaa (started, ips) when Int64.sub now started > t.aaaa_timeout ->
+    let ips = List.map (fun ip -> Ipaddr.V4 ip) (Ipaddr.V4.Set.elements ips) in
+    let dst, dsts = expand_list_split ips conn.ports in
+    let state = Connecting (now, dst, dsts) in
+    Ok ({ conn with state }, [ Connect (host, id, dst) ])
+  | Connecting (started, (ip, _), dsts) ->
+    (* if there are further IP addresses, and our connection attempt is to an
+       IPv6 address, use the v6_connect_timeout. Otherwise, use the
+       connect_timeout. *)
+    let timeout = match ip, dsts with
+      | Ipaddr.V6 _, _ :: _ -> t.v6_connect_timeout
+      | _, _ -> t.connect_timeout
+    in
+    if Int64.sub now started > timeout then
       (* TODO cancel previous connection attempt *)
       (match dsts with
-       | [] -> if conn.resolved = `both then Error () else Ok (Resolving, [])
-       | dst :: dsts -> Ok (Connecting (now, dst, dsts), [ Connect (host, id, dst) ]))
-    | x -> Ok (x, [])
-  with
-  | Ok (state, actions) -> Ok ({ conn with state }, actions)
-  | Error () -> Error ()
+       | [] ->
+         if conn.resolved = `both then
+           Error ()
+         else
+           Ok ({ conn with state = Resolving }, [])
+       | dst :: dsts ->
+         let state = Connecting (now, dst, dsts) in
+         Ok ({ conn with state }, [ Connect (host, id, dst) ]))
+    else
+      Ok (conn, [])
+  | _ -> Ok (conn, [])
 
 let timer t now =
   Log.debug (fun m -> m "timer");
@@ -143,7 +167,13 @@ let timer t now =
 
 let connect t now ~id host ports =
   if ports = [] then failwith "empty port list not supported";
-  let conn = { created = now ; ports ; state = Resolving ; resolved = `none } in
+  let conn = {
+    created = now ;
+    ports ;
+    state = Resolving ;
+    resolved = `none ;
+    resolve_left = t.resolve_retries
+  } in
   { t with conns = add_conn host id conn t.conns },
   [ Resolve_aaaa host ; Resolve_a host ]
 
@@ -207,7 +237,13 @@ let connect_ip t now ~id dsts =
     | [] -> failwith "addresses are empty"
   in
   let state = Connecting (now, dst, dsts) in
-  let conn = { created = now ; ports = [] ; state ; resolved = `both } in
+  let conn = {
+    created = now ;
+    ports = [] ;
+    state ;
+    resolved = `both ;
+    resolve_left = t.resolve_retries
+  } in
   let host = Domain_name.(host_exn (of_string_exn "host.invalid")) in
   { t with conns = add_conn host id conn t.conns },
   [ Connect (host, id, dst) ]

--- a/src/happy_eyeballs.mli
+++ b/src/happy_eyeballs.mli
@@ -23,14 +23,16 @@ type event =
 val pp_event : event Fmt.t
 (** [pp_event ppf e] pretty-prints event [e] on [ppf]. *)
 
-val create : ?aaaa_timeout:int64 -> ?connect_timeout:int64 ->
-  ?resolve_timeout:int64 -> int64 -> t
-(** [create ~aaaa_timeout ~connect_timeout ~resolve_timeout ts] creates the
-    internal state, initialized with the timestamp [ts] (an arbitrary number
-    that must be monotonically increasing). The timeouts are specified in
-    nanoseconds: the default of [aaaa_timeout] is [Duration.of_ms 50],
-    [connect_timeout] and [resolve_timeout] use a default of
-    [Duration.of_sec 1]. *)
+val create : ?aaaa_timeout:int64 -> ?v6_connect_timeout:int64 ->
+  ?connect_timeout:int64 -> ?resolve_timeout:int64 -> ?resolve_retries:int ->
+  int64 -> t
+(** [create ~aaaa_timeout ~v6_connect_timeout ~connect_timeout ~resolve_timeout ~resolve_retries ts]
+    creates the internal state, initialized with the timestamp [ts] (an
+    arbitrary number that must be monotonically increasing). The timeouts are
+    specified in nanoseconds: the default of [aaaa_timeout] is
+    [Duration.of_ms 50], [v6_connect_timeout] is [Duration.of_ms 200],
+    [connect_timeout] is [Duration.of_sec 10], and [resolve_timeout] is
+    [Duration.of_sec 1]. The [resolve_retries] defaults to 3. *)
 
 val timer : t -> int64 -> t * [ `Suspend | `Act ] * action list
 (** [timer t ts] is a timer function that results in an updated [t] and either


### PR DESCRIPTION
DNS resolution may fail, by default, retry resolving 3 times (when there's no
resolution within resolve_timeout).

The connect_timeout is used for all connection attempts to the last destination.
If there is a connection attempt to an IPv6 address (and others are remaining),
use v6_connect_timeout (default 200ms) instead. This is the same value as curl.
In some network environments, the previously used connect_timeout of one second
was not sufficient to establish a complete connection.