### PR TITLE
Demote log levels

### DIFF
--- a/src/happy_eyeballs.ml
+++ b/src/happy_eyeballs.ml
@@ -265,8 +265,9 @@ let event t now e =
     let conns, actions =
       match Domain_name.Host_map.find name t.conns with
       | None ->
-        Log.warn (fun m -> m "resolved %a, but no entry in conns"
-                     Domain_name.pp name);
+        (* XXX: DEBUG and not WARN because of missing cancellation logic *)
+        Log.debug (fun m -> m "resolved %a, but no entry in conns"
+                      Domain_name.pp name);
         t.conns, []
       | Some cs ->
         let cs, actions = IM.fold (fun id c (cs, actions) ->
@@ -298,8 +299,9 @@ let event t now e =
     let conns, actions =
       match Domain_name.Host_map.find name t.conns with
       | None ->
-        Log.warn (fun m -> m "resolve A %a failed, but no entry in conns"
-                     Domain_name.pp name);
+        (* XXX: DEBUG and not WARN because of missing cancellation logic *)
+        Log.debug (fun m -> m "resolve A %a failed, but no entry in conns"
+                      Domain_name.pp name);
         t.conns, []
       | Some cs ->
         let cs, actions = IM.fold (fun id c (cs, actions) ->
@@ -320,8 +322,9 @@ let event t now e =
     let conns, actions =
       match Domain_name.Host_map.find name t.conns with
       | None ->
-        Log.warn (fun m -> m "resolved %a, but no entry in conns"
-                     Domain_name.pp name);
+        (* XXX: DEBUG and not WARN because of missing cancellation logic *)
+        Log.debug (fun m -> m "resolved %a, but no entry in conns"
+                      Domain_name.pp name);
         t.conns, []
       | Some cs ->
         let cs, actions = IM.fold (fun id c (cs, actions) ->
@@ -349,8 +352,9 @@ let event t now e =
     let conns, actions =
       match Domain_name.Host_map.find name t.conns with
       | None ->
-        Log.warn (fun m -> m "resolve AAAA %a failed, but no entry in conns"
-                     Domain_name.pp name);
+        (* XXX: DEBUG and not WARN because of missing cancellation logic *)
+        Log.debug (fun m -> m "resolve AAAA %a failed, but no entry in conns"
+                      Domain_name.pp name);
         t.conns, []
       | Some cs ->
         let cs, actions = IM.fold (fun id c (cs, actions) ->
@@ -379,8 +383,9 @@ let event t now e =
     let conns, actions =
       match Domain_name.Host_map.find name t.conns with
       | None ->
-        Log.warn (fun m -> m "connection failed to %a, but no entry in conns"
-                     Domain_name.pp name);
+        (* XXX: DEBUG and not WARN because of missing cancellation logic *)
+        Log.debug (fun m -> m "connection failed to %a, but no entry in conns"
+                      Domain_name.pp name);
         t.conns, []
       | Some cs ->
         match IM.find_opt id cs with


### PR DESCRIPTION
At the moment we are missing cancellation logic for connection attempts and DNS resolution when a connection is established after a timeout or similar. This means happy-eyeballs sometimes prints a lot of warnings that are benign.