### PR TITLE
happy-eyeballs: use the domain name of the first IP in connect_ip as identifier

### DIFF
--- a/src/happy_eyeballs.ml
+++ b/src/happy_eyeballs.ml
@@ -254,7 +254,7 @@ let connect_ip t now ~id dsts =
     resolved = `both ;
     resolve_left = 0 ;
   } in
-  let host = Domain_name.(host_exn (of_string_exn "host.invalid")) in
+  let host = Ipaddr.to_domain_name (fst dst) in
   { t with conns = add_conn host id conn t.conns },
   [ Connect (host, id, dst) ]
 


### PR DESCRIPTION
previously, "host.invalid" was used which does not contain any useful information

//cc @reynir 