### PR TITLE
cancellation and log messages

### DIFF
--- a/lwt/happy_eyeballs_lwt.ml
+++ b/lwt/happy_eyeballs_lwt.ml
@@ -1,4 +1,3 @@
-
 (* Lwt tasks are spawned:
  - create starts an asynchronous timer task
  - the actions resulting from timer are scheduled in one separate task
@@ -6,15 +5,22 @@
    respective separate tasks
 *)
 
-(* TODO - cancellation of connection attempts *)
-
 let src = Logs.Src.create "happy-eyeballs.lwt" ~doc:"Happy Eyeballs Lwt"
 module Log = (val Logs.src_log src : Logs.LOG)
 
 let now = Mtime_clock.elapsed_ns
 
+module Name_id = Map.Make(struct
+    type t = [`host] Domain_name.t * int
+    let compare (h, id) (h', id') =
+      match Domain_name.compare h h' with
+      | 0 -> Int.compare id id'
+      | x -> x
+  end)
+
 type t = {
   mutable waiters : ((Ipaddr.t * int) * Lwt_unix.file_descr, [ `Msg of string ]) result Lwt.u Happy_eyeballs.Waiter_map.t ;
+  mutable connecting : (Lwt_unix.file_descr, [ `Msg of string ]) result Lwt.t Name_id.t;
   mutable he : Happy_eyeballs.t ;
   dns : Dns_client_lwt.t ;
   timer_interval : float ;
@@ -41,9 +47,13 @@ let try_connect ip port =
        let addr = Lwt_unix.ADDR_INET (Ipaddr_unix.to_inet_addr ip, port) in
        Lwt_result.ok (Lwt_unix.connect fd addr) >|= fun () ->
        fd)
-    (fun e ->
-       Lwt_result.ok (safe_close fd) >>= fun () ->
-       Lwt_result.fail (`Msg ("connect failure: " ^ Printexc.to_string e)))
+    (function
+      | Lwt.Canceled ->
+        Lwt_result.ok (safe_close fd) >>= fun () ->
+        Lwt_result.fail (`Msg "cancelled")
+      | e ->
+        Lwt_result.ok (safe_close fd) >>= fun () ->
+        Lwt_result.fail (`Msg ("connect failure: " ^ Printexc.to_string e)))
 
 let rec act t action =
   let open Lwt.Infix in
@@ -54,17 +64,21 @@ let rec act t action =
       begin
         Dns_client_lwt.getaddrinfo t.dns Dns.Rr_map.A host >|= function
         | Ok (_, res) -> Ok (Happy_eyeballs.Resolved_a (host, res))
-        | Error _ -> Ok (Happy_eyeballs.Resolved_a_failed host)
+        | Error `Msg msg -> Ok (Happy_eyeballs.Resolved_a_failed (host, msg))
       end
     | Happy_eyeballs.Resolve_aaaa host ->
       begin
         Dns_client_lwt.getaddrinfo t.dns Dns.Rr_map.Aaaa host >|= function
         | Ok (_, res) -> Ok (Happy_eyeballs.Resolved_aaaa (host, res))
-        | Error _ -> Ok (Happy_eyeballs.Resolved_aaaa_failed host)
+        | Error `Msg msg -> Ok (Happy_eyeballs.Resolved_aaaa_failed (host, msg))
       end
     | Happy_eyeballs.Connect (host, id, (ip, port)) ->
       begin
-        try_connect ip port >>= function
+        let th = try_connect ip port in
+        t.connecting <- Name_id.add (host, id) th t.connecting;
+        th >>= fun r ->
+        t.connecting <- Name_id.remove (host, id) t.connecting;
+        match r with
         | Ok fd ->
           let waiters, r = Happy_eyeballs.Waiter_map.find_and_remove id t.waiters in
           t.waiters <- waiters;
@@ -77,22 +91,29 @@ let rec act t action =
               safe_close fd >>= fun () ->
               Lwt.return (Error ())
           end
-        | Error _ ->
-          Lwt.return (Ok (Happy_eyeballs.Connection_failed (host, id, (ip, port))))
+        | Error `Msg msg ->
+          Lwt.return (Ok (Happy_eyeballs.Connection_failed (host, id, (ip, port), msg)))
       end
-    | Happy_eyeballs.Connect_failed (_host, id) ->
+    | Happy_eyeballs.Connect_cancelled (host, id) ->
+      begin
+        match Name_id.find_opt (host, id) t.connecting with
+        | None -> ()
+        | Some th -> Lwt.cancel th
+      end;
+      Lwt.return (Error ())
+    | Happy_eyeballs.Connect_failed (_host, id, msg) ->
       let waiters, r = Happy_eyeballs.Waiter_map.find_and_remove id t.waiters in
       t.waiters <- waiters;
       begin match r with
         | Some waiter ->
-          Lwt.wakeup_later waiter (Error (`Msg "connection failed"));
+          Lwt.wakeup_later waiter (Error (`Msg ("connection failed: " ^ msg)));
           Lwt.return (Error ())
         | None ->
           (* waiter already vanished *)
           Lwt.return (Error ())
       end
   end >>= function
-  | Error _ -> Lwt.return_unit
+  | Error () -> Lwt.return_unit
   | Ok ev ->
     let he, actions = Happy_eyeballs.event t.he (now ()) ev in
     t.he <- he;
@@ -120,9 +141,10 @@ let rec timer t =
 let create ?(happy_eyeballs = Happy_eyeballs.create (now ())) ?(dns = Dns_client_lwt.create ()) ?(timer_interval = Duration.of_ms 10) () =
   let waiters = Happy_eyeballs.Waiter_map.empty
   and timer_condition = Lwt_condition.create ()
+  and connecting = Name_id.empty
   in
   let timer_interval = Duration.to_f timer_interval in
-  let t = { waiters ; he = happy_eyeballs ; dns ; timer_interval ; timer_condition } in
+  let t = { waiters ; connecting ; he = happy_eyeballs ; dns ; timer_interval ; timer_condition } in
   Lwt.async (fun () -> timer t);
   t
 

--- a/mirage/happy_eyeballs_mirage.ml
+++ b/mirage/happy_eyeballs_mirage.ml
@@ -85,7 +85,7 @@ end = struct
           t.connecting <- Happy_eyeballs.Waiter_map.add id th t.connecting;
           (Lwt.catch (fun () -> th)
              (function
-               | Lwt.Canceled -> Error (`Msg "cancelled")
+               | Lwt.Canceled -> Lwt.return_error (`Msg "cancelled")
                | e -> (* TODO: Lwt.reraise *) raise e)) >>= fun r ->
           t.connecting <- Happy_eyeballs.Waiter_map.remove id t.connecting;
           match r with

--- a/mirage/happy_eyeballs_mirage.ml
+++ b/mirage/happy_eyeballs_mirage.ml
@@ -83,7 +83,10 @@ end = struct
         begin
           let th = try_connect t.stack ip port in
           t.connecting <- Happy_eyeballs.Waiter_map.add id th t.connecting;
-          th >>= fun r ->
+          (Lwt.catch (fun () -> th)
+             (function
+               | Lwt.Canceled -> Error (`Msg "cancelled")
+               | e -> (* TODO: Lwt.reraise *) raise e)) >>= fun r ->
           t.connecting <- Happy_eyeballs.Waiter_map.remove id t.connecting;
           match r with
           | Ok flow ->

--- a/mirage/happy_eyeballs_mirage.ml
+++ b/mirage/happy_eyeballs_mirage.ml
@@ -27,8 +27,6 @@ end
    respective separate tasks
 *)
 
-(* TODO - cancellation of connection attempts *)
-
 let src = Logs.Src.create "happy-eyeballs.mirage" ~doc:"Happy Eyeballs Mirage"
 module Log = (val Logs.src_log src : Logs.LOG)
 
@@ -46,16 +44,25 @@ end = struct
   module Transport = DNS.Transport
   type dns = DNS.t
 
+  type flow = S.TCP.flow
+
+  module Name_id = Map.Make(struct
+    type t = [`host] Domain_name.t * int
+    let compare (h, id) (h', id') =
+      match Domain_name.compare h h' with
+      | 0 -> Int.compare id id'
+      | x -> x
+  end)
+
   type t = {
     dns : DNS.t ;
     stack : S.t ;
     mutable waiters : ((Ipaddr.t * int) * S.TCP.flow, [ `Msg of string ]) result Lwt.u Happy_eyeballs.Waiter_map.t ;
+    mutable connecting : (flow, [ `Msg of string ]) result Lwt.t Name_id.t;
     mutable he : Happy_eyeballs.t ;
     timer_interval : int64 ;
     timer_condition : unit Lwt_condition.t ;
   }
-
-  type flow = S.TCP.flow
 
   let try_connect stack ip port =
     let open Lwt.Infix in
@@ -72,17 +79,21 @@ end = struct
         begin
           DNS.getaddrinfo t.dns Dns.Rr_map.A host >|= function
           | Ok (_, res) -> Ok (Happy_eyeballs.Resolved_a (host, res))
-          | Error _ -> Ok (Happy_eyeballs.Resolved_a_failed host)
+          | Error `Msg msg -> Ok (Happy_eyeballs.Resolved_a_failed (host, msg))
         end
       | Happy_eyeballs.Resolve_aaaa host ->
         begin
           DNS.getaddrinfo t.dns Dns.Rr_map.Aaaa host >|= function
           | Ok (_, res) -> Ok (Happy_eyeballs.Resolved_aaaa (host, res))
-          | Error _ -> Ok (Happy_eyeballs.Resolved_aaaa_failed host)
+          | Error `Msg msg -> Ok (Happy_eyeballs.Resolved_aaaa_failed (host, msg))
         end
       | Happy_eyeballs.Connect (host, id, (ip, port)) ->
         begin
-          try_connect t.stack ip port >>= function
+          let th = try_connect t.stack ip port in
+          t.connecting <- Name_id.add (host, id) th t.connecting;
+          th >>= fun r ->
+          t.connecting <- Name_id.remove (host, id) t.connecting;
+          match r with
           | Ok flow ->
             let waiters, r = Happy_eyeballs.Waiter_map.find_and_remove id t.waiters in
             t.waiters <- waiters;
@@ -95,15 +106,21 @@ end = struct
                 S.TCP.close flow >>= fun () ->
                 Lwt.return (Error ())
             end
-          | Error _ ->
-            Lwt.return (Ok (Happy_eyeballs.Connection_failed (host, id, (ip, port))))
+          | Error `Msg msg ->
+            Lwt.return (Ok (Happy_eyeballs.Connection_failed (host, id, (ip, port), msg)))
         end
-      | Happy_eyeballs.Connect_failed (_host, id) ->
+      | Happy_eyeballs.Connect_cancelled (host, id) ->
+        begin match Name_id.find_opt (host, id) t.connecting with
+          | None -> ()
+          | Some th -> Lwt.cancel th
+        end;
+        Lwt.return (Error ())
+      | Happy_eyeballs.Connect_failed (_host, id, msg) ->
         let waiters, r = Happy_eyeballs.Waiter_map.find_and_remove id t.waiters in
         t.waiters <- waiters;
         begin match r with
           | Some waiter ->
-            Lwt.wakeup_later waiter (Error (`Msg "connection failed"));
+            Lwt.wakeup_later waiter (Error (`Msg ("connection failed: " ^ msg)));
             Lwt.return (Error ())
           | None ->
             (* waiter already vanished *)
@@ -138,8 +155,9 @@ end = struct
   let create ?(happy_eyeballs = Happy_eyeballs.create (C.elapsed_ns ())) ?dns ?(timer_interval = Duration.of_ms 10) stack =
     let dns = match dns with None -> DNS.create stack | Some x -> x
     and timer_condition = Lwt_condition.create ()
+    and connecting = Name_id.empty
     in
-    let t = { dns ; stack ; waiters = Happy_eyeballs.Waiter_map.empty ; he = happy_eyeballs ; timer_interval ; timer_condition } in
+    let t = { dns ; stack ; waiters = Happy_eyeballs.Waiter_map.empty ; connecting ; he = happy_eyeballs ; timer_interval ; timer_condition } in
     Lwt.async (fun () -> timer t);
     t
 

--- a/src/happy_eyeballs.ml
+++ b/src/happy_eyeballs.ml
@@ -404,7 +404,10 @@ let event t now e =
   | Connected (name, id, (_ip, _port)) ->
     let conns =
       Domain_name.Host_map.update name (function
-          | None -> None
+          | None ->
+            Log.warn (fun m -> m "connected to an unexpected domain: %a"
+                         Domain_name.pp name);
+            None
           | Some xs ->
             let m = IM.remove id xs in
             if IM.cardinal m = 0 then None else Some m)

--- a/src/happy_eyeballs.ml
+++ b/src/happy_eyeballs.ml
@@ -264,11 +264,7 @@ let event t now e =
   | Resolved_a (name, ips) ->
     let conns, actions =
       match Domain_name.Host_map.find name t.conns with
-      | None ->
-        (* XXX: DEBUG and not WARN because of missing cancellation logic *)
-        Log.debug (fun m -> m "resolved %a, but no entry in conns"
-                      Domain_name.pp name);
-        t.conns, []
+      | None -> t.conns, []
       | Some cs ->
         let cs, actions = IM.fold (fun id c (cs, actions) ->
             let resolved = resolve c.resolved `v4 in
@@ -298,11 +294,7 @@ let event t now e =
   | Resolved_a_failed name ->
     let conns, actions =
       match Domain_name.Host_map.find name t.conns with
-      | None ->
-        (* XXX: DEBUG and not WARN because of missing cancellation logic *)
-        Log.debug (fun m -> m "resolve A %a failed, but no entry in conns"
-                      Domain_name.pp name);
-        t.conns, []
+      | None -> t.conns, []
       | Some cs ->
         let cs, actions = IM.fold (fun id c (cs, actions) ->
             let resolved = resolve c.resolved `v4 in
@@ -321,11 +313,7 @@ let event t now e =
   | Resolved_aaaa (name, ips) ->
     let conns, actions =
       match Domain_name.Host_map.find name t.conns with
-      | None ->
-        (* XXX: DEBUG and not WARN because of missing cancellation logic *)
-        Log.debug (fun m -> m "resolved %a, but no entry in conns"
-                      Domain_name.pp name);
-        t.conns, []
+      | None -> t.conns, []
       | Some cs ->
         let cs, actions = IM.fold (fun id c (cs, actions) ->
             let resolved = resolve c.resolved `v6 in
@@ -351,11 +339,7 @@ let event t now e =
   | Resolved_aaaa_failed name ->
     let conns, actions =
       match Domain_name.Host_map.find name t.conns with
-      | None ->
-        (* XXX: DEBUG and not WARN because of missing cancellation logic *)
-        Log.debug (fun m -> m "resolve AAAA %a failed, but no entry in conns"
-                      Domain_name.pp name);
-        t.conns, []
+      | None -> t.conns, []
       | Some cs ->
         let cs, actions = IM.fold (fun id c (cs, actions) ->
             let resolved = resolve c.resolved `v6 in

--- a/src/happy_eyeballs.ml
+++ b/src/happy_eyeballs.ml
@@ -33,12 +33,14 @@ type t = {
   conns : connection IM.t Domain_name.Host_map.t ;
 }
 
+type id = int
+
 type action =
   | Resolve_a of [`host] Domain_name.t
   | Resolve_aaaa of [`host] Domain_name.t
-  | Connect of [`host] Domain_name.t * int * (Ipaddr.t * int)
-  | Connect_failed of [`host] Domain_name.t * int * string
-  | Connect_cancelled of [`host] Domain_name.t * int
+  | Connect of [`host] Domain_name.t * id * (Ipaddr.t * int)
+  | Connect_failed of [`host] Domain_name.t * id * string
+  | Connect_cancelled of [`host] Domain_name.t * id
 
 let pp_action ppf = function
   | Resolve_a host -> Fmt.pf ppf "resolve A %a" Domain_name.pp host
@@ -56,8 +58,8 @@ type event =
   | Resolved_aaaa of [`host] Domain_name.t * Ipaddr.V6.Set.t
   | Resolved_a_failed of [`host] Domain_name.t * string
   | Resolved_aaaa_failed of [`host] Domain_name.t * string
-  | Connection_failed of [`host] Domain_name.t * int * (Ipaddr.t * int) * string
-  | Connected of [`host] Domain_name.t * int * (Ipaddr.t * int)
+  | Connection_failed of [`host] Domain_name.t * id * (Ipaddr.t * int) * string
+  | Connected of [`host] Domain_name.t * id * (Ipaddr.t * int)
 
 let pp_event ppf = function
   | Resolved_a (host, ips) ->
@@ -424,5 +426,4 @@ module Waiter_map = struct
     match find_opt id t with
     | None -> t, None
     | Some x -> remove id t, Some x
-
 end

--- a/src/happy_eyeballs.ml
+++ b/src/happy_eyeballs.ml
@@ -37,7 +37,8 @@ type action =
   | Resolve_a of [`host] Domain_name.t
   | Resolve_aaaa of [`host] Domain_name.t
   | Connect of [`host] Domain_name.t * int * (Ipaddr.t * int)
-  | Connect_failed of [`host] Domain_name.t * int
+  | Connect_failed of [`host] Domain_name.t * int * string
+  | Connect_cancelled of [`host] Domain_name.t * int
 
 let pp_action ppf = function
   | Resolve_a host -> Fmt.pf ppf "resolve A %a" Domain_name.pp host
@@ -45,15 +46,17 @@ let pp_action ppf = function
   | Connect (host, id, (ip, port)) ->
     Fmt.pf ppf "%u connect %a (using %a:%u)" id Domain_name.pp host
       Ipaddr.pp ip port
-  | Connect_failed (host, id) ->
-    Fmt.pf ppf "%u connect failed %a" id Domain_name.pp host
+  | Connect_failed (host, id, reason) ->
+    Fmt.pf ppf "%u connect failed %a: %s" id Domain_name.pp host reason
+  | Connect_cancelled (host, id) ->
+    Fmt.pf ppf "%u connect cancelled %a" id Domain_name.pp host
 
 type event =
   | Resolved_a of [`host] Domain_name.t * Ipaddr.V4.Set.t
   | Resolved_aaaa of [`host] Domain_name.t * Ipaddr.V6.Set.t
-  | Resolved_a_failed of [`host] Domain_name.t
-  | Resolved_aaaa_failed of [`host] Domain_name.t
-  | Connection_failed of [`host] Domain_name.t * int * (Ipaddr.t * int)
+  | Resolved_a_failed of [`host] Domain_name.t * string
+  | Resolved_aaaa_failed of [`host] Domain_name.t * string
+  | Connection_failed of [`host] Domain_name.t * int * (Ipaddr.t * int) * string
   | Connected of [`host] Domain_name.t * int * (Ipaddr.t * int)
 
 let pp_event ppf = function
@@ -65,13 +68,13 @@ let pp_event ppf = function
     Fmt.pf ppf "resolved AAAA %a: %a" Domain_name.pp host
       Fmt.(list ~sep:(any ", ") Ipaddr.V6.pp)
       (Ipaddr.V6.Set.elements ips)
-  | Resolved_a_failed host ->
-    Fmt.pf ppf "resolve A failed for %a" Domain_name.pp host
-  | Resolved_aaaa_failed host ->
-    Fmt.pf ppf "resolve AAAA failed for %a" Domain_name.pp host
-  | Connection_failed (host, id, (ip, port)) ->
-    Fmt.pf ppf "%u connection to %a failed %a:%d" id Domain_name.pp host
-      Ipaddr.pp ip port
+  | Resolved_a_failed (host, reason) ->
+    Fmt.pf ppf "resolve A failed for %a: %s" Domain_name.pp host reason
+  | Resolved_aaaa_failed (host, reason) ->
+    Fmt.pf ppf "resolve AAAA failed for %a: %s" Domain_name.pp host reason
+  | Connection_failed (host, id, (ip, port), reason) ->
+    Fmt.pf ppf "%u connection to %a failed %a:%d: %s" id Domain_name.pp host
+      Ipaddr.pp ip port reason
   | Connected (host, id, (ip, port)) ->
     Fmt.pf ppf "%u connected to %a (using %a:%d)" id Domain_name.pp host
       Ipaddr.pp ip port
@@ -118,7 +121,7 @@ let tick t now host id conn =
             actions)
       in
       match conn.resolve_left <= 1, conn.resolved with
-      | true, _ | _, `both -> Error ()
+      | true, _ | _, `both -> Error []
       | false, `none -> ok [ Resolve_a host ; Resolve_aaaa host ]
       | false, `v4 -> ok [ Resolve_aaaa host ]
       | false, `v6 -> ok [ Resolve_a host ]
@@ -137,16 +140,16 @@ let tick t now host id conn =
       | _, _ -> t.connect_timeout
     in
     if Int64.sub now started > timeout then
-      (* TODO cancel previous connection attempt *)
+      let cancel = Connect_cancelled (host, id) in
       (match dsts with
        | [] ->
          if conn.resolved = `both then
-           Error ()
+           Error [cancel]
          else
-           Ok ({ conn with state = Resolving }, [])
+           Ok ({ conn with state = Resolving }, [cancel])
        | dst :: dsts ->
          let state = Connecting (now, dst, dsts) in
-         Ok ({ conn with state }, [ Connect (host, id, dst) ]))
+         Ok ({ conn with state }, [ cancel ; Connect (host, id, dst) ]))
     else
       Ok (conn, [])
   | _ -> Ok (conn, [])
@@ -158,7 +161,8 @@ let timer t now =
         let v, actions = IM.fold (fun id conn (acc, actions) ->
             match tick t now host id conn with
             | Ok (conn, action) -> IM.add id conn acc, actions @ action
-            | Error () -> acc, actions @ [ Connect_failed (host, id) ]
+            | Error action ->
+              acc, actions @ action @ [ Connect_failed (host, id, "timeout") ]
           ) v (IM.empty, actions)
         in
         let dm =
@@ -291,7 +295,7 @@ let event t now e =
         Domain_name.Host_map.add name cs t.conns, actions
     in
     { t with conns }, actions
-  | Resolved_a_failed name ->
+  | Resolved_a_failed (name, reason) ->
     let conns, actions =
       match Domain_name.Host_map.find name t.conns with
       | None -> t.conns, []
@@ -300,7 +304,7 @@ let event t now e =
             let resolved = resolve c.resolved `v4 in
             match c.state with
             | Resolving when resolved = `both ->
-              cs, Connect_failed (name, id) :: actions
+              cs, Connect_failed (name, id, reason) :: actions
             | _ -> IM.add id { c with resolved } cs, actions)
             cs (IM.empty, [])
         in
@@ -336,7 +340,7 @@ let event t now e =
         Domain_name.Host_map.add name cs t.conns, actions
     in
     { t with conns }, actions
-  | Resolved_aaaa_failed name ->
+  | Resolved_aaaa_failed (name, reason) ->
     let conns, actions =
       match Domain_name.Host_map.find name t.conns with
       | None -> t.conns, []
@@ -345,7 +349,7 @@ let event t now e =
             let resolved = resolve c.resolved `v6 in
             match c.state with
             | Resolving when resolved = `both ->
-              cs, Connect_failed (name, id) :: actions
+              cs, Connect_failed (name, id, reason) :: actions
             | Waiting_for_aaaa (_ts, ips) ->
               let ips =
                 List.map (fun ip -> Ipaddr.V4 ip) (Ipaddr.V4.Set.elements ips)
@@ -363,19 +367,18 @@ let event t now e =
            Domain_name.Host_map.add name cs t.conns), actions
     in
     { t with conns }, actions
-  | Connection_failed (name, id, (ip, port)) ->
+  | Connection_failed (name, id, (ip, port), reason) ->
     let conns, actions =
       match Domain_name.Host_map.find name t.conns with
       | None ->
-        (* XXX: DEBUG and not WARN because of missing cancellation logic *)
-        Log.debug (fun m -> m "connection failed to %a, but no entry in conns"
-                      Domain_name.pp name);
+        Log.warn (fun m -> m "connection failed to %a: %s; no entry in conns"
+                     Domain_name.pp name reason);
         t.conns, []
       | Some cs ->
         match IM.find_opt id cs with
         | None ->
-          Log.warn (fun m -> m "%u connection failed to %a, but no entry in IM"
-                       id Domain_name.pp name);
+          Log.warn (fun m -> m "%u connection failed to %a: %s; no entry in IM"
+                       id Domain_name.pp name reason);
           t.conns, []
         | Some c ->
           let is_dst (ip', port') = Ipaddr.compare ip ip' = 0 && port = port' in
@@ -383,7 +386,7 @@ let event t now e =
           | Connecting (_ts, dst, []) when is_dst dst && c.resolved = `both ->
             let cs = IM.remove id cs in
             Domain_name.Host_map.add name cs t.conns,
-            [ Connect_failed (name, id) ]
+            [ Connect_failed (name, id, reason) ]
           | Connecting (_ts, dst, []) when is_dst dst ->
             let state = Resolving in
             let cs = IM.add id { c with state } cs in

--- a/src/happy_eyeballs.mli
+++ b/src/happy_eyeballs.mli
@@ -6,7 +6,8 @@ type action =
   | Resolve_a of [`host] Domain_name.t
   | Resolve_aaaa of [`host] Domain_name.t
   | Connect of [`host] Domain_name.t * int * (Ipaddr.t * int)
-  | Connect_failed of [`host] Domain_name.t * int
+  | Connect_failed of [`host] Domain_name.t * int * string
+  | Connect_cancelled of [`host] Domain_name.t * int
 
 val pp_action : action Fmt.t
 (** [pp_action ppf a] pretty-prints the action [a] on [ppf]. *)
@@ -15,9 +16,9 @@ val pp_action : action Fmt.t
 type event =
   | Resolved_a of [`host] Domain_name.t * Ipaddr.V4.Set.t
   | Resolved_aaaa of [`host] Domain_name.t * Ipaddr.V6.Set.t
-  | Resolved_a_failed of [`host] Domain_name.t
-  | Resolved_aaaa_failed of [`host] Domain_name.t
-  | Connection_failed of [`host] Domain_name.t * int * (Ipaddr.t * int)
+  | Resolved_a_failed of [`host] Domain_name.t * string
+  | Resolved_aaaa_failed of [`host] Domain_name.t * string
+  | Connection_failed of [`host] Domain_name.t * int * (Ipaddr.t * int) * string
   | Connected of [`host] Domain_name.t * int * (Ipaddr.t * int)
 
 val pp_event : event Fmt.t


### PR DESCRIPTION
but there's no entry in the connection table (we won't cancel DNS resolution)

This is based on the observation that cancellation will only be reasonable for connecton attempts (since they already have identifiers and use resources).

//cc @reynir