### PR TITLE
Fix connection establishment.

### DIFF
--- a/lwt/happy_eyeballs_lwt.ml
+++ b/lwt/happy_eyeballs_lwt.ml
@@ -99,7 +99,7 @@ let rec act t action =
         in
         Lwt.pick [ conn; (cancelled >|= fun () -> Error ()); ]
       end
-    | Happy_eyeballs.Connect_failed (_host, id, msg) ->
+    | Happy_eyeballs.Connect_failed (host, id, msg) ->
       let cancel_connecting, others =
         Happy_eyeballs.Waiter_map.find_and_remove id t.cancel_connecting
       in
@@ -109,7 +109,14 @@ let rec act t action =
       t.waiters <- waiters;
       begin match r with
         | Some waiter ->
-          Lwt.wakeup_later waiter (Error (`Msg ("connection failed: " ^ msg)));
+          let err =
+            Fmt.str "connection to %s failed: %s"
+              (match Ipaddr.of_domain_name host with
+               | None -> Domain_name.to_string host
+               | Some ip -> Ipaddr.to_string ip)
+              msg
+          in
+          Lwt.wakeup_later waiter (Error (`Msg err));
           Lwt.return (Error ())
         | None ->
           (* waiter already vanished *)

--- a/lwt/happy_eyeballs_lwt.ml
+++ b/lwt/happy_eyeballs_lwt.ml
@@ -12,7 +12,7 @@ let now = Mtime_clock.elapsed_ns
 
 type t = {
   mutable waiters : ((Ipaddr.t * int) * Lwt_unix.file_descr, [ `Msg of string ]) result Lwt.u Happy_eyeballs.Waiter_map.t ;
-  mutable cancel_connecting : unit Lwt.u Happy_eyeballs.Waiter_map.t;
+  mutable cancel_connecting : (int * unit Lwt.u) list Happy_eyeballs.Waiter_map.t;
   mutable he : Happy_eyeballs.t ;
   dns : Dns_client_lwt.t ;
   timer_interval : float ;
@@ -60,38 +60,45 @@ let rec act t action =
         | Ok (_, res) -> Ok (Happy_eyeballs.Resolved_aaaa (host, res))
         | Error `Msg msg -> Ok (Happy_eyeballs.Resolved_aaaa_failed (host, msg))
       end
-    | Happy_eyeballs.Connect (host, id, (ip, port)) ->
+    | Happy_eyeballs.Connect (host, id, attempt, (ip, port)) ->
       begin
         let cancelled, cancel = Lwt.task () in
-        t.cancel_connecting <- Happy_eyeballs.Waiter_map.add id cancel t.cancel_connecting;
-        Lwt.pick [
-            try_connect ip port;
-            (cancelled >|= fun () -> Error (`Msg "cancelled"));
-          ] >>= fun r ->
-        t.cancel_connecting <- Happy_eyeballs.Waiter_map.remove id t.cancel_connecting;
-        match r with
-        | Ok fd ->
-          let waiters, r = Happy_eyeballs.Waiter_map.find_and_remove id t.waiters in
-          t.waiters <- waiters;
-          begin match r with
-            | Some waiter ->
-              Lwt.wakeup_later waiter (Ok ((ip, port), fd));
-              Lwt.return (Ok (Happy_eyeballs.Connected (host, id, (ip, port))))
-            | None ->
-              (* waiter already vanished *)
-              safe_close fd >>= fun () ->
-              Lwt.return (Error ())
-          end
-        | Error `Msg msg ->
-          Lwt.return (Ok (Happy_eyeballs.Connection_failed (host, id, (ip, port), msg)))
+        let entry = attempt, cancel in
+        t.cancel_connecting <-
+          Happy_eyeballs.Waiter_map.update id
+            (function None -> Some [ entry ] | Some c -> Some (entry :: c))
+            t.cancel_connecting;
+        let conn =
+          try_connect ip port >>= function
+          | Ok fd ->
+            let cancel_connecting, others =
+              Happy_eyeballs.Waiter_map.find_and_remove id t.cancel_connecting
+            in
+            t.cancel_connecting <- cancel_connecting;
+            List.iter (fun (_, w) -> Lwt.wakeup_later w ()) (Option.value ~default:[] others);
+            let waiters, r = Happy_eyeballs.Waiter_map.find_and_remove id t.waiters in
+            t.waiters <- waiters;
+            begin match r with
+              | Some waiter ->
+                Lwt.wakeup_later waiter (Ok ((ip, port), fd));
+                Lwt.return (Ok (Happy_eyeballs.Connected (host, id, (ip, port))))
+              | None ->
+                (* waiter already vanished *)
+                safe_close fd >>= fun () ->
+                Lwt.return (Error ())
+            end
+          | Error `Msg msg ->
+            t.cancel_connecting <-
+              Happy_eyeballs.Waiter_map.update id
+                (function None -> None | Some c ->
+                  match List.filter (fun (att, _) -> not (att = attempt)) c with
+                  | [] -> None
+                  | c -> Some c)
+                t.cancel_connecting;
+            Lwt.return (Ok (Happy_eyeballs.Connection_failed (host, id, (ip, port), msg)))
+        in
+        Lwt.pick [ conn; (cancelled >|= fun () -> Error ()); ]
       end
-    | Happy_eyeballs.Connect_cancelled (_host, id) ->
-      begin
-        match Happy_eyeballs.Waiter_map.find_opt id t.cancel_connecting with
-        | None -> ()
-        | Some th -> Lwt.wakeup th ()
-      end;
-      Lwt.return (Error ())
     | Happy_eyeballs.Connect_failed (_host, id, msg) ->
       let waiters, r = Happy_eyeballs.Waiter_map.find_and_remove id t.waiters in
       t.waiters <- waiters;
@@ -129,7 +136,13 @@ let rec timer t =
   Lwt_condition.wait t.timer_condition >>= fun () ->
   loop ()
 
-let create ?(happy_eyeballs = Happy_eyeballs.create (now ())) ?(dns = Dns_client_lwt.create ()) ?(timer_interval = Duration.of_ms 10) () =
+let create ?(happy_eyeballs = Happy_eyeballs.create (now ())) ?dns ?(timer_interval = Duration.of_ms 10) () =
+  let dns =
+    Option.value ~default:
+      (let timeout = Happy_eyeballs.resolve_timeout happy_eyeballs in
+       Dns_client_lwt.create ~timeout ())
+      dns
+  in
   let waiters = Happy_eyeballs.Waiter_map.empty
   and cancel_connecting = Happy_eyeballs.Waiter_map.empty
   and timer_condition = Lwt_condition.create ()

--- a/lwt/happy_eyeballs_lwt.ml
+++ b/lwt/happy_eyeballs_lwt.ml
@@ -75,7 +75,8 @@ let rec act t action =
               Happy_eyeballs.Waiter_map.find_and_remove id t.cancel_connecting
             in
             t.cancel_connecting <- cancel_connecting;
-            List.iter (fun (_, w) -> Lwt.wakeup_later w ()) (Option.value ~default:[] others);
+            List.iter (fun (att, w) -> if att <> attempt then Lwt.wakeup_later w ())
+              (Option.value ~default:[] others);
             let waiters, r = Happy_eyeballs.Waiter_map.find_and_remove id t.waiters in
             t.waiters <- waiters;
             begin match r with

--- a/mirage/happy_eyeballs_mirage.ml
+++ b/mirage/happy_eyeballs_mirage.ml
@@ -119,6 +119,11 @@ end = struct
           Lwt.pick [ conn ; (cancelled >|= fun () -> Error ()); ]
         end
       | Happy_eyeballs.Connect_failed (_host, id, msg) ->
+        let cancel_connecting, others =
+          Happy_eyeballs.Waiter_map.find_and_remove id t.cancel_connecting
+        in
+        t.cancel_connecting <- cancel_connecting;
+        List.iter (fun (_, u) -> Lwt.wakeup_later u ()) (Option.value ~default:[] others);
         let waiters, r = Happy_eyeballs.Waiter_map.find_and_remove id t.waiters in
         t.waiters <- waiters;
         begin match r with

--- a/mirage/happy_eyeballs_mirage.ml
+++ b/mirage/happy_eyeballs_mirage.ml
@@ -37,6 +37,7 @@ module Make (T : Mirage_time.S) (C : Mirage_clock.MCLOCK) (S : Tcpip.Stack.V4V6)
      and type dns = DNS.t
      and type flow = S.TCP.flow
 
+  (* note: the v6_connect_timeout is kept until 1.0.0 since it is referenced in mirage *)
   val connect_device : ?aaaa_timeout:int64 -> ?connect_delay:int64 ->
     ?v6_connect_timeout:int64 -> ?connect_timeout:int64 -> ?resolve_timeout:int64 -> ?resolve_retries:int ->
     ?timer_interval:int64 -> dns -> Transport.stack -> t Lwt.t
@@ -233,6 +234,7 @@ end = struct
         (Result.bind (Domain_name.of_string host) Domain_name.host) >>= fun h ->
       connect_host t h ports
 
+  (* note: the v6_connect_timeout is kept until 1.0.0 since it is referenced in mirage *)
   let connect_device ?aaaa_timeout ?connect_delay ?v6_connect_timeout:_ ?connect_timeout
     ?resolve_timeout ?resolve_retries ?timer_interval dns stack =
     let happy_eyeballs =

--- a/mirage/happy_eyeballs_mirage.ml
+++ b/mirage/happy_eyeballs_mirage.ml
@@ -38,7 +38,7 @@ module Make (T : Mirage_time.S) (C : Mirage_clock.MCLOCK) (S : Tcpip.Stack.V4V6)
      and type flow = S.TCP.flow
 
   val connect_device : ?aaaa_timeout:int64 -> ?connect_delay:int64 ->
-    ?connect_timeout:int64 -> ?resolve_timeout:int64 -> ?resolve_retries:int ->
+    ?v6_connect_timeout:int64 -> ?connect_timeout:int64 -> ?resolve_timeout:int64 -> ?resolve_retries:int ->
     ?timer_interval:int64 -> dns -> Transport.stack -> t Lwt.t
 end = struct
   module Transport = DNS.Transport
@@ -88,13 +88,14 @@ end = struct
               (function None -> Some [ entry ] | Some c -> Some (entry :: c))
               t.cancel_connecting;
           let conn =
-            try_connect t.stack addr >>= function
+            try_connect t.stack addr >|= function
             | Ok flow ->
               let cancel_connecting, others =
                 Happy_eyeballs.Waiter_map.find_and_remove id t.cancel_connecting
               in
               t.cancel_connecting <- cancel_connecting;
-              List.iter (fun (_, u) -> Lwt.wakeup_later u ()) (Option.value ~default:[] others);
+              List.iter (fun (att, u) -> if att <> attempt then Lwt.wakeup_later u ()) 
+                (Option.value ~default:[] others);
               let waiters, r = Happy_eyeballs.Waiter_map.find_and_remove id t.waiters in
               t.waiters <- waiters;
               begin match r with
@@ -232,7 +233,7 @@ end = struct
         (Result.bind (Domain_name.of_string host) Domain_name.host) >>= fun h ->
       connect_host t h ports
 
-  let connect_device ?aaaa_timeout ?connect_delay ?connect_timeout
+  let connect_device ?aaaa_timeout ?connect_delay ?v6_connect_timeout:_ ?connect_timeout
     ?resolve_timeout ?resolve_retries ?timer_interval dns stack =
     let happy_eyeballs =
       Happy_eyeballs.create ?aaaa_timeout ?connect_delay ?connect_timeout

--- a/mirage/happy_eyeballs_mirage.ml
+++ b/mirage/happy_eyeballs_mirage.ml
@@ -88,13 +88,13 @@ end = struct
               (function None -> Some [ entry ] | Some c -> Some (entry :: c))
               t.cancel_connecting;
           let conn =
-            try_connect t.stack addr >|= function
+            try_connect t.stack addr >>= function
             | Ok flow ->
               let cancel_connecting, others =
                 Happy_eyeballs.Waiter_map.find_and_remove id t.cancel_connecting
               in
               t.cancel_connecting <- cancel_connecting;
-              List.iter (fun (att, u) -> if att <> attempt then Lwt.wakeup_later u ()) 
+              List.iter (fun (att, u) -> if att <> attempt then Lwt.wakeup_later u ())
                 (Option.value ~default:[] others);
               let waiters, r = Happy_eyeballs.Waiter_map.find_and_remove id t.waiters in
               t.waiters <- waiters;

--- a/mirage/happy_eyeballs_mirage.ml
+++ b/mirage/happy_eyeballs_mirage.ml
@@ -37,7 +37,7 @@ module Make (T : Mirage_time.S) (C : Mirage_clock.MCLOCK) (S : Tcpip.Stack.V4V6)
      and type dns = DNS.t
      and type flow = S.TCP.flow
 
-  val connect_device : ?aaaa_timeout:int64 -> ?v6_connect_timeout:int64 ->
+  val connect_device : ?aaaa_timeout:int64 -> ?connect_delay:int64 ->
     ?connect_timeout:int64 -> ?resolve_timeout:int64 -> ?resolve_retries:int ->
     ?timer_interval:int64 -> dns -> Transport.stack -> t Lwt.t
 end = struct
@@ -50,15 +50,15 @@ end = struct
     dns : DNS.t ;
     stack : S.t ;
     mutable waiters : ((Ipaddr.t * int) * S.TCP.flow, [ `Msg of string ]) result Lwt.u Happy_eyeballs.Waiter_map.t ;
-    mutable cancel_connecting : unit Lwt.u Happy_eyeballs.Waiter_map.t;
+    mutable cancel_connecting : (int * unit Lwt.u) list Happy_eyeballs.Waiter_map.t;
     mutable he : Happy_eyeballs.t ;
     timer_interval : int64 ;
     timer_condition : unit Lwt_condition.t ;
   }
 
-  let try_connect stack ip port =
+  let try_connect stack addr =
     let open Lwt.Infix in
-    S.TCP.create_connection (S.tcp stack) (ip, port) >|= fun r ->
+    S.TCP.create_connection (S.tcp stack) addr >|= fun r ->
     Result.map_error
       (fun err -> `Msg (Fmt.to_to_string S.TCP.pp_error err)) r
 
@@ -79,37 +79,45 @@ end = struct
           | Ok (_, res) -> Ok (Happy_eyeballs.Resolved_aaaa (host, res))
           | Error `Msg msg -> Ok (Happy_eyeballs.Resolved_aaaa_failed (host, msg))
         end
-      | Happy_eyeballs.Connect (host, id, (ip, port)) ->
+      | Happy_eyeballs.Connect (host, id, attempt, addr) ->
         begin
           let cancelled, cancel = Lwt.task () in
-          t.cancel_connecting <- Happy_eyeballs.Waiter_map.add id cancel t.cancel_connecting;
-          Lwt.pick [
-            try_connect t.stack ip port ;
-            (cancelled >|= fun () -> Error (`Msg "cancelled"));
-          ] >>= fun r ->
-          t.cancel_connecting <- Happy_eyeballs.Waiter_map.remove id t.cancel_connecting;
-          match r with
-          | Ok flow ->
-            let waiters, r = Happy_eyeballs.Waiter_map.find_and_remove id t.waiters in
-            t.waiters <- waiters;
-            begin match r with
-              | Some waiter ->
-                Lwt.wakeup_later waiter (Ok ((ip, port), flow));
-                Lwt.return (Ok (Happy_eyeballs.Connected (host, id, (ip, port))))
-              | None ->
-                (* waiter already vanished *)
-                S.TCP.close flow >>= fun () ->
-                Lwt.return (Error ())
-            end
-          | Error `Msg msg ->
-            Lwt.return (Ok (Happy_eyeballs.Connection_failed (host, id, (ip, port), msg)))
+          let entry = attempt, cancel in
+          t.cancel_connecting <-
+            Happy_eyeballs.Waiter_map.update id
+              (function None -> Some [ entry ] | Some c -> Some (entry :: c))
+              t.cancel_connecting;
+          let conn =
+            try_connect t.stack addr >>= function
+            | Ok flow ->
+              let cancel_connecting, others =
+                Happy_eyeballs.Waiter_map.find_and_remove id t.cancel_connecting
+              in
+              t.cancel_connecting <- cancel_connecting;
+              List.iter (fun (_, u) -> Lwt.wakeup_later u ()) (Option.value ~default:[] others);
+              let waiters, r = Happy_eyeballs.Waiter_map.find_and_remove id t.waiters in
+              t.waiters <- waiters;
+              begin match r with
+                | Some waiter ->
+                  Lwt.wakeup_later waiter (Ok (addr, flow));
+                  Lwt.return (Ok (Happy_eyeballs.Connected (host, id, addr)))
+                | None ->
+                  (* waiter already vanished *)
+                  S.TCP.close flow >>= fun () ->
+                  Lwt.return (Error ())
+              end
+            | Error `Msg msg ->
+              t.cancel_connecting <-
+                Happy_eyeballs.Waiter_map.update id
+                  (function None -> None | Some c ->
+                    match List.filter (fun (att, _) -> not (att = attempt)) c with
+                    | [] -> None
+                    | c -> Some c)
+                  t.cancel_connecting;
+              Lwt.return (Ok (Happy_eyeballs.Connection_failed (host, id, addr, msg)))
+          in
+          Lwt.pick [ conn ; (cancelled >|= fun () -> Error ()); ]
         end
-      | Happy_eyeballs.Connect_cancelled (_host, id) ->
-        begin match Happy_eyeballs.Waiter_map.find_opt id t.cancel_connecting with
-          | None -> ()
-          | Some th -> Lwt.wakeup_later th ()
-        end;
-        Lwt.return (Error ())
       | Happy_eyeballs.Connect_failed (_host, id, msg) ->
         let waiters, r = Happy_eyeballs.Waiter_map.find_and_remove id t.waiters in
         t.waiters <- waiters;
@@ -148,7 +156,11 @@ end = struct
     loop ()
 
   let create ?(happy_eyeballs = Happy_eyeballs.create (C.elapsed_ns ())) ?dns ?(timer_interval = Duration.of_ms 10) stack =
-    let dns = match dns with None -> DNS.create stack | Some x -> x
+    let dns =
+      Option.value ~default:
+        (let timeout = Happy_eyeballs.resolve_timeout happy_eyeballs in
+         DNS.create ~timeout stack)
+        dns
     and waiters = Happy_eyeballs.Waiter_map.empty
     and cancel_connecting = Happy_eyeballs.Waiter_map.empty
     and timer_condition = Lwt_condition.create ()
@@ -208,10 +220,10 @@ end = struct
         (Result.bind (Domain_name.of_string host) Domain_name.host) >>= fun h ->
       connect_host t h ports
 
-  let connect_device ?aaaa_timeout ?v6_connect_timeout ?connect_timeout
+  let connect_device ?aaaa_timeout ?connect_delay ?connect_timeout
     ?resolve_timeout ?resolve_retries ?timer_interval dns stack =
     let happy_eyeballs =
-      Happy_eyeballs.create ?aaaa_timeout ?v6_connect_timeout ?connect_timeout
+      Happy_eyeballs.create ?aaaa_timeout ?connect_delay ?connect_timeout
         ?resolve_timeout ?resolve_retries (C.elapsed_ns ())
     in
     let happy_eyeballs = create ~happy_eyeballs ~dns ?timer_interval stack in

--- a/mirage/happy_eyeballs_mirage.mli
+++ b/mirage/happy_eyeballs_mirage.mli
@@ -27,6 +27,7 @@ module Make (T : Mirage_time.S) (C : Mirage_clock.MCLOCK) (S : Tcpip.Stack.V4V6)
     and type dns = DNS.t
     and type flow = S.TCP.flow
 
+  (* note: the v6_connect_timeout is kept until 1.0.0 since it is referenced in mirage *)
   val connect_device : ?aaaa_timeout:int64 -> ?connect_delay:int64 ->
     ?v6_connect_timeout:int64 -> ?connect_timeout:int64 -> ?resolve_timeout:int64 -> ?resolve_retries:int ->
     ?timer_interval:int64 -> dns -> Transport.stack -> t Lwt.t

--- a/mirage/happy_eyeballs_mirage.mli
+++ b/mirage/happy_eyeballs_mirage.mli
@@ -28,6 +28,6 @@ module Make (T : Mirage_time.S) (C : Mirage_clock.MCLOCK) (S : Tcpip.Stack.V4V6)
     and type flow = S.TCP.flow
 
   val connect_device : ?aaaa_timeout:int64 -> ?connect_delay:int64 ->
-    ?connect_timeout:int64 -> ?resolve_timeout:int64 -> ?resolve_retries:int ->
+    ?v6_connect_timeout:int64 -> ?connect_timeout:int64 -> ?resolve_timeout:int64 -> ?resolve_retries:int ->
     ?timer_interval:int64 -> dns -> Transport.stack -> t Lwt.t
 end

--- a/mirage/happy_eyeballs_mirage.mli
+++ b/mirage/happy_eyeballs_mirage.mli
@@ -27,7 +27,7 @@ module Make (T : Mirage_time.S) (C : Mirage_clock.MCLOCK) (S : Tcpip.Stack.V4V6)
     and type dns = DNS.t
     and type flow = S.TCP.flow
 
-  val connect_device : ?aaaa_timeout:int64 -> ?v6_connect_timeout:int64 ->
+  val connect_device : ?aaaa_timeout:int64 -> ?connect_delay:int64 ->
     ?connect_timeout:int64 -> ?resolve_timeout:int64 -> ?resolve_retries:int ->
     ?timer_interval:int64 -> dns -> Transport.stack -> t Lwt.t
 end

--- a/src/happy_eyeballs.ml
+++ b/src/happy_eyeballs.ml
@@ -52,9 +52,9 @@ let host_or_ip v =
 let pp_action ppf = function
   | Resolve_a host -> Fmt.pf ppf "resolve A %a" Domain_name.pp host
   | Resolve_aaaa host -> Fmt.pf ppf "resolve AAAA %a" Domain_name.pp host
-  | Connect (host, id, id', (ip, port)) ->
+  | Connect (host, id, attempt, (ip, port)) ->
     Fmt.pf ppf "%u connect %s (using %a:%u), attempt %u" id (host_or_ip host)
-         Ipaddr.pp ip port id'
+         Ipaddr.pp ip port attempt
   | Connect_failed (host, id, reason) ->
     Fmt.pf ppf "%u connect failed %s: %s" id (host_or_ip host) reason
 
@@ -171,7 +171,6 @@ let timer t now =
         in
         dm, actions) t.conns (Domain_name.Host_map.empty, [])
   in
-  let actions = List.rev actions in
   (match actions with
    | [] when not (Domain_name.Host_map.is_empty conns) -> ()
    | _ ->

--- a/src/happy_eyeballs.mli
+++ b/src/happy_eyeballs.mli
@@ -8,9 +8,8 @@ type id
 type action =
   | Resolve_a of [`host] Domain_name.t
   | Resolve_aaaa of [`host] Domain_name.t
-  | Connect of [`host] Domain_name.t * id * (Ipaddr.t * int)
+  | Connect of [`host] Domain_name.t * id * int * (Ipaddr.t * int)
   | Connect_failed of [`host] Domain_name.t * id * string
-  | Connect_cancelled of [`host] Domain_name.t * id
 
 val pp_action : action Fmt.t
 (** [pp_action ppf a] pretty-prints the action [a] on [ppf]. *)
@@ -27,14 +26,14 @@ type event =
 val pp_event : event Fmt.t
 (** [pp_event ppf e] pretty-prints event [e] on [ppf]. *)
 
-val create : ?aaaa_timeout:int64 -> ?v6_connect_timeout:int64 ->
+val create : ?aaaa_timeout:int64 -> ?connect_delay:int64 ->
   ?connect_timeout:int64 -> ?resolve_timeout:int64 -> ?resolve_retries:int ->
   int64 -> t
-(** [create ~aaaa_timeout ~v6_connect_timeout ~connect_timeout ~resolve_timeout ~resolve_retries ts]
+(** [create ~aaaa_timeout ~connect_delay ~connect_timeout ~resolve_timeout ~resolve_retries ts]
     creates the internal state, initialized with the timestamp [ts] (an
     arbitrary number that must be monotonically increasing). The timeouts are
     specified in nanoseconds: the default of [aaaa_timeout] is
-    [Duration.of_ms 50], [v6_connect_timeout] is [Duration.of_ms 200],
+    [Duration.of_ms 50], [connect_delay] is [Duration.of_ms 50],
     [connect_timeout] is [Duration.of_sec 10], and [resolve_timeout] is
     [Duration.of_sec 1]. The [resolve_retries] defaults to 3. *)
 
@@ -70,6 +69,9 @@ val event : t -> int64 -> event -> t * action list
     performed.
 
     @raise Failure if [ev] contains an empty set of IP addresses. *)
+
+val resolve_timeout : t -> int64
+(** [resolve_timeout t] is the timeout for the resolver in nanoseconds. *)
 
 (** A map for waiters and internal id. *)
 module Waiter_map : sig


### PR DESCRIPTION
Consider a connection to IP addressed [ ::1 ; 127.1 ].

This should give some preference to ::1, but should attempt a connection to both ::1 and 127.1.

Earlier, the sequence of actions was as follows:
- Connect ::1
- Wait for v6_connect_timeout, connect_failed, or connected
- Cancel connection attempt to ::1; Connect 127.1
- Wait for connect_timeout, connect_failed, or connected

This means the connection to the IPv6 address was only waiting for v6_connect_timeout time, and then being cancelled. There were no two connection being attempted to be established at the same time.

Some DNS resolvers on the azure cloud (where Github actions are hosted) do not reply on port 853 (DNS-over-TLS), but just drop the packets. This confused the happy-eyeballs/dns-client stack, and it resulted in a timeout (as spotted by semgrep).

With this PR, the above scenario is changed to:
- Connect ::1
- Wait for connect_delay, connect_failed, or connected
- Connect 127.1
- Wait for connect_timeout, connect_failed, or connected
- Cancel all other connection attempts (on success or timeout)

And the same is applied to using a single IP address and multiple ports (i.e. for the DNS resolver probing port 853 and 53).

Sponsored-By: Semgrep Inc